### PR TITLE
Fix memory corruption due to publisher-multithreading

### DIFF
--- a/src/ICPlocalization.cpp
+++ b/src/ICPlocalization.cpp
@@ -305,14 +305,10 @@ void ICPlocalization::icpWorker() {
 
 //    ROS_INFO_STREAM_THROTTLE(10.0, "Scan matching took: " << timeMs << " ms");
 
-		std::thread t([this]() {
-			publishPose();
-			publishRegisteredCloud();
-		});
+		publishPose();
+		publishRegisteredCloud();
 
-		t.detach();
 		r.sleep();
-
 	}
 }
 


### PR DESCRIPTION
For us, the publishing in a separate thread was causing memory corruption and crashes that occurred only sporadically and when ICP was running for an extended period of time (> 1 h). This is likely due to the lack of a mutex mechanism, resulting in reading data to publish while data might be changing from the other thread.

Also, since the publisher thread gets spawned and destroyed on every loop cycle, the time gain was not noticable for us. If it is still desired, a more optimal way would probably be to use a thread that gets spawned once and then gets fed data to publish by a mutexed queuing mechanism (which the ROS publishers have probably built-in already anyway).

See https://github.com/ethz-asl/moma/pull/149